### PR TITLE
Change bitcoin docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./setup.py:/usr/src/app/setup.py
     command: py.test -v
   bitcoin:
-    image: sbellem/bitcoin
+    image: ascribe/bitcoin
     volumes:
       -  ./.bitcoin:/root/.bitcoin
     ports:


### PR DESCRIPTION
so that we use the one hosted under ascribe org: https://hub.docker.com/r/ascribe/bitcoin/