### PR TITLE
Set minimum confirmations to 1

### DIFF
--- a/tests/test_blockr_service.py
+++ b/tests/test_blockr_service.py
@@ -140,7 +140,7 @@ def test_raw_get_transaction(alice, bob, alice_to_bob_txid, blockr):
 def test_push_tx(alice, bob, alice_secret, blockr):
     from transactions import Transactions
     transactions = Transactions(testnet=True)
-    raw_tx = transactions.create(alice, (bob, 1))
+    raw_tx = transactions.create(alice, (bob, 1), min_confirmations=1)
     signed_tx = transactions.sign(raw_tx, alice_secret)
     txid = blockr.push_tx(signed_tx)
     assert txid
@@ -149,7 +149,7 @@ def test_push_tx(alice, bob, alice_secret, blockr):
 def test_raw_push_tx(alice, bob, alice_secret, blockr):
     from transactions import Transactions
     transactions = Transactions(testnet=True)
-    raw_tx = transactions.create(alice, (bob, 1))
+    raw_tx = transactions.create(alice, (bob, 1), min_confirmations=1)
     signed_tx = transactions.sign(raw_tx, alice_secret)
     response = blockr.push_tx(signed_tx, raw=True)
     assert response.status_code == 200

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -197,7 +197,9 @@ def test_transaction_creation_via_simple_transaction_with_blockr(alice, bob):
     from transactions import Transactions
     trxs = Transactions(testnet=True)
     assert trxs.testnet is True
-    simple_transaction = trxs.simple_transaction(alice, (bob, 6))
+    simple_transaction = trxs.simple_transaction(alice,
+                                                 (bob, 6),
+                                                 min_confirmations=1)
     assert simple_transaction
 
 
@@ -205,5 +207,5 @@ def test_transaction_creation_via_create_with_blockr(alice, bob):
     from transactions import Transactions
     trxs = Transactions(testnet=True)
     assert trxs.testnet is True
-    simple_transaction = trxs.create(alice, (bob, 6))
+    simple_transaction = trxs.create(alice, (bob, 6), min_confirmations=1)
     assert simple_transaction


### PR DESCRIPTION
to make it quicker for tests to pass if the testnet wallet had to be refilled